### PR TITLE
やっぱりテーマはライトテーマにしたい

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -13,9 +13,9 @@ class App extends StatelessWidget {
     return MaterialApp.router(
       onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
       routerConfig: router,
-      theme: appDarkTheme,
+      theme: appLightTheme,
       darkTheme: appDarkTheme,
-      themeMode: ThemeMode.dark,
+      themeMode: ThemeMode.light,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
     );

--- a/lib/app/app_theme.dart
+++ b/lib/app/app_theme.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 final appLightTheme = ThemeData(
   useMaterial3: true,
   colorScheme: ColorScheme.fromSeed(
-    seedColor: Colors.teal,
+    seedColor: Colors.orange,
   ),
 );
 
@@ -12,7 +12,7 @@ final appLightTheme = ThemeData(
 final appDarkTheme = ThemeData(
   useMaterial3: true,
   colorScheme: ColorScheme.fromSeed(
-    seedColor: Colors.teal,
+    seedColor: Colors.orange,
     brightness: Brightness.dark,
   ),
 );

--- a/lib/app/app_theme.dart
+++ b/lib/app/app_theme.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// NoZanLane 全体で利用するライトテーマです。
+final appLightTheme = ThemeData(
+  useMaterial3: true,
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: Colors.teal,
+  ),
+);
+
 /// NoZanLane 全体で利用するダークテーマです。
 final appDarkTheme = ThemeData(
   useMaterial3: true,

--- a/lib/widgetbook/app.dart
+++ b/lib/widgetbook/app.dart
@@ -13,9 +13,9 @@ class WidgetbookApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Widgetbook.material(
-      lightTheme: appDarkTheme,
+      lightTheme: appLightTheme,
       darkTheme: appDarkTheme,
-      themeMode: ThemeMode.dark,
+      themeMode: ThemeMode.light,
       directories: directories,
     );
   }


### PR DESCRIPTION
close #20

# 概要
ライトテーマを追加し、ダークテーマを保持したまま、表示テーマを常にライトに固定しました。

# 変更内容
- `app_theme.dart` に `appLightTheme` を追加
- `App` の `theme` を `appLightTheme` に変更
- `App` の `themeMode` を `ThemeMode.light` に変更
- `WidgetbookApp` の `lightTheme` を `appLightTheme` に変更
- `WidgetbookApp` の `themeMode` を `ThemeMode.light` に変更

# 懸念事項
- ダークテーマ定義は残していますが、現状では表示に使われません（将来の切替要件向けに保持）。
