### PR TITLE
Figma MCP を使い、コンポーネントを自動生成する環境を作る

### DIFF
--- a/.codex/skills/impl-component/SKILL.md
+++ b/.codex/skills/impl-component/SKILL.md
@@ -30,3 +30,8 @@ description: 共通コンポーネントを実装するスキルです。
 # Widgetbook 登録
 
 - 共通コンポーネントを追加したら Widgetbook にも登録する
+
+# Figma URL がある場合
+
+- Figma URL が指定されていたら Figma MCP を使い、指定の Component を実装する
+- コンポーネント名は Figma のコンポーネント名と同じにする

--- a/.github/ISSUE_TEMPLATE/component_from_figma.md
+++ b/.github/ISSUE_TEMPLATE/component_from_figma.md
@@ -1,0 +1,12 @@
+---
+name: コンポーネント実装依頼
+about: Figma URL を元に共通コンポーネントを実装する
+title: "[Component] "
+labels: ""
+assignees: ""
+---
+
+impl-component スキルを使い、以下のコンポーネントを実装してください。
+
+# Figma URL
+


### PR DESCRIPTION
close #23

# 概要
Figma MCP を使ったコンポーネント実装フローを整備するため、Issue テンプレートと impl-component スキルを更新しました。

# 変更内容
- .github/ISSUE_TEMPLATE/component_from_figma.md を追加
- impl-component スキルに以下を追記
  - Figma URL 指定時は Figma MCP を利用して実装する
  - コンポーネント名は Figma のコンポーネント名に合わせる

# 懸念事項
- なし