### PR TITLE
[Component] DSCampaignBanner

### DIFF
--- a/.codex/skills/impl-component/SKILL.md
+++ b/.codex/skills/impl-component/SKILL.md
@@ -30,6 +30,7 @@ description: 共通コンポーネントを実装するスキルです。
 # Widgetbook 登録
 
 - 共通コンポーネントを追加したら Widgetbook にも登録する
+- UseCase メソッドの命名は「コンポーネント名のキャメルケース + UseCase」とする
 
 # Figma URL がある場合
 

--- a/lib/component/ds_campaign_banner.dart
+++ b/lib/component/ds_campaign_banner.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// 複数画面で利用可能なキャンペーンバナーです。
+class DSCampaignBanner extends StatelessWidget {
+  /// [DSCampaignBanner] を生成します。
+  const DSCampaignBanner({
+    required this.text,
+    super.key,
+    this.backgroundColor = const Color(0xFFFF9800),
+  });
+
+  /// バナーに表示する文言です。
+  final String text;
+
+  /// バナー背景色です。
+  final Color backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: backgroundColor,
+      child: SizedBox(
+        height: 48,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              text,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgetbook/app.directories.g.dart
+++ b/lib/widgetbook/app.directories.g.dart
@@ -26,7 +26,7 @@ final directories = <_widgetbook.WidgetbookNode>[
           _widgetbook.WidgetbookUseCase(
             name: 'Default',
             builder: _no_zan_lane_widgetbook_component_ds_app_bar_use_case
-                .dsAppBarDefaultUseCase,
+                .dsAppBarUseCase,
           ),
         ],
       ),
@@ -37,7 +37,7 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'Default',
             builder:
                 _no_zan_lane_widgetbook_component_ds_campaign_banner_use_case
-                    .dsCampaignBannerDefaultUseCase,
+                    .dsCampaignBannerUseCase,
           ),
         ],
       ),

--- a/lib/widgetbook/app.directories.g.dart
+++ b/lib/widgetbook/app.directories.g.dart
@@ -12,6 +12,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:no_zan_lane/widgetbook/component/ds_app_bar_use_case.dart'
     as _no_zan_lane_widgetbook_component_ds_app_bar_use_case;
+import 'package:no_zan_lane/widgetbook/component/ds_campaign_banner_use_case.dart'
+    as _no_zan_lane_widgetbook_component_ds_campaign_banner_use_case;
 import 'package:widgetbook/widgetbook.dart' as _widgetbook;
 
 final directories = <_widgetbook.WidgetbookNode>[
@@ -25,6 +27,17 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'Default',
             builder: _no_zan_lane_widgetbook_component_ds_app_bar_use_case
                 .dsAppBarDefaultUseCase,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'DSCampaignBanner',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Default',
+            builder:
+                _no_zan_lane_widgetbook_component_ds_campaign_banner_use_case
+                    .dsCampaignBannerDefaultUseCase,
           ),
         ],
       ),

--- a/lib/widgetbook/component/ds_app_bar_use_case.dart
+++ b/lib/widgetbook/component/ds_app_bar_use_case.dart
@@ -7,7 +7,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
   type: DSAppBar,
 )
 /// [DSAppBar] のデフォルトユースケースです。
-Widget dsAppBarDefaultUseCase(BuildContext context) {
+Widget dsAppBarUseCase(BuildContext context) {
   return const Scaffold(
     appBar: DSAppBar(titleText: 'Widgetbook DSAppBar'),
     body: SizedBox.shrink(),

--- a/lib/widgetbook/component/ds_campaign_banner_use_case.dart
+++ b/lib/widgetbook/component/ds_campaign_banner_use_case.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:no_zan_lane/component/ds_campaign_banner.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'Default',
+  type: DSCampaignBanner,
+)
+/// [DSCampaignBanner] のデフォルトユースケースです。
+Widget dsCampaignBannerDefaultUseCase(BuildContext context) {
+  return const Scaffold(
+    body: Center(
+      child: SizedBox(
+        width: 320,
+        child: DSCampaignBanner(text: 'キャンペーンテキスト'),
+      ),
+    ),
+  );
+}

--- a/lib/widgetbook/component/ds_campaign_banner_use_case.dart
+++ b/lib/widgetbook/component/ds_campaign_banner_use_case.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:no_zan_lane/component/ds_app_bar.dart';
 import 'package:no_zan_lane/component/ds_campaign_banner.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
@@ -7,13 +8,9 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
   type: DSCampaignBanner,
 )
 /// [DSCampaignBanner] のデフォルトユースケースです。
-Widget dsCampaignBannerDefaultUseCase(BuildContext context) {
+Widget dsCampaignBannerUseCase(BuildContext context) {
   return const Scaffold(
-    body: Center(
-      child: SizedBox(
-        width: 320,
-        child: DSCampaignBanner(text: 'キャンペーンテキスト'),
-      ),
-    ),
+    appBar: DSAppBar(titleText: 'DSCampaignBanner'),
+    body: DSCampaignBanner(text: 'キャンペーンテキスト'),
   );
 }


### PR DESCRIPTION
close #25

# 概要
DSCampaignBanner コンポーネントを実装し、Widgetbook UseCase 命名規約の反映と表示位置の調整を行いました。

# 変更内容
- `lib/component/ds_campaign_banner.dart` に `DSCampaignBanner` を追加
- `lib/widgetbook/component/ds_campaign_banner_use_case.dart` を追加し、`DSAppBar` 付きでバナーを直下に配置
- UseCase メソッド命名を `コンポーネント名のキャメルケース + UseCase` に統一
  - `dsAppBarUseCase`
  - `dsCampaignBannerUseCase`
- `build_runner` 実行により `lib/widgetbook/app.directories.g.dart` を更新

# 懸念事項
- 特になし
