### PR TITLE
Android Edge-to-edge 対応

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,9 +11,9 @@ Future<void> main() async {
       statusBarColor: Colors.transparent,
       systemNavigationBarColor: Colors.transparent,
       systemNavigationBarDividerColor: Colors.transparent,
-      statusBarIconBrightness: Brightness.light,
-      systemNavigationBarIconBrightness: Brightness.light,
-      systemNavigationBarContrastEnforced: false,
+      statusBarIconBrightness: Brightness.dark,
+      systemNavigationBarIconBrightness: Brightness.dark,
+      systemNavigationBarContrastEnforced: true,
     ),
   );
   runApp(const ProviderScope(child: App()));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,20 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:no_zan_lane/app/app.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+  SystemChrome.setSystemUIOverlayStyle(
+    const SystemUiOverlayStyle(
+      statusBarColor: Colors.transparent,
+      systemNavigationBarColor: Colors.transparent,
+      systemNavigationBarDividerColor: Colors.transparent,
+      statusBarIconBrightness: Brightness.light,
+      systemNavigationBarIconBrightness: Brightness.light,
+      systemNavigationBarContrastEnforced: false,
+    ),
+  );
   runApp(const ProviderScope(child: App()));
 }


### PR DESCRIPTION
close #38

# 概要
Android で Edge-to-edge 表示を有効化し、コンテンツをステータスバーおよびシステムナビゲーションバー領域まで描画可能にしました。

# 変更内容
- main 初期化時に SystemUiMode.edgeToEdge を設定
- ステータスバー/ナビゲーションバー/ナビゲーションバー区切り線を透過化
- ナビゲーションバーのコントラスト強制を無効化

# 懸念事項
- システムバー領域に実際に描画するには、各画面で SafeArea や Scaffold の設定（例: extendBodyBehindAppBar）を用途に応じて調整する必要があります