### PR TITLE
Widgetbook でレスポンシブ対応を検証できるようにする。

### DIFF
--- a/lib/widgetbook/app.dart
+++ b/lib/widgetbook/app.dart
@@ -18,7 +18,12 @@ class WidgetbookApp extends StatelessWidget {
       themeMode: ThemeMode.light,
       directories: directories,
       addons: [
-        ViewportAddon(Viewports.all),
+        ViewportAddon([
+          IosViewports.iPhone12Mini,
+          ...Viewports.all.where(
+            (viewport) => viewport != IosViewports.iPhone12Mini,
+          ),
+        ]),
       ],
     );
   }

--- a/lib/widgetbook/app.dart
+++ b/lib/widgetbook/app.dart
@@ -17,6 +17,9 @@ class WidgetbookApp extends StatelessWidget {
       darkTheme: appDarkTheme,
       themeMode: ThemeMode.light,
       directories: directories,
+      addons: [
+        ViewportAddon(Viewports.all),
+      ],
     );
   }
 }


### PR DESCRIPTION
close #46

# 概要
Widgetbook でレスポンシブ確認を行えるようにするため、Issue #46 の方針どおり `ViewportAddon` のみを追加しました。

# 変更内容
- `lib/widgetbook/app.dart` の `Widgetbook.material` に `addons` を追加
- `ViewportAddon(Viewports.all)` を設定
- `DeviceFrameAddon` は追加していません

# 懸念事項
- `Viewports.all` にはデスクトップ向け viewport も含まれるため、運用上不要であれば今後絞り込みの検討余地があります
