### PR TITLE
impl-frameスキル改善と画面実装テンプレート追加

### DIFF
--- a/.agents/skills/impl-frame/SKILL.md
+++ b/.agents/skills/impl-frame/SKILL.md
@@ -19,3 +19,20 @@ description: 画面を実装するときに使います。
 
 # Riverpod の使い方はまだ未定義
 
+# Widgetbook 登録
+
+- Frame を追加したら Widgetbook にも登録する
+- UseCase メソッドの命名は「画面名のキャメルケース + UseCase」とする
+
+## 画面状態
+
+- 画面状態は Riverpod の override を使うことで、Widgetbook 用に固定の画面状態を提供してください。
+
+# Figma URL がある場合
+
+- Figma URL が指定されていたら Figma MCP を使い、指定の Frame を実装する
+- 画面クラス名は Figma の Frame 名と同じにする
+
+## Edge-to-edge 対応
+
+- Figma 上のステータスバーとナビゲーションバーの重なりを考慮して実装してください。

--- a/.github/ISSUE_TEMPLATE/frame_from_figma.md
+++ b/.github/ISSUE_TEMPLATE/frame_from_figma.md
@@ -1,0 +1,12 @@
+---
+name: 画面実装依頼
+about: Figma URL を元に画面を実装する
+title: "[Frame] "
+labels: ""
+assignees: ""
+---
+
+impl-frame スキルを使い、以下の画面を実装してください。
+
+# Figma URL
+


### PR DESCRIPTION
# 概要
impl-frame スキルのガイドラインを改善し、画面実装依頼の Issue テンプレートを追加しました。

# 変更内容
- .agents/skills/impl-frame/SKILL.md に Widgetbook 登録と Figma 対応のガイドラインを追加
- .github/ISSUE_TEMPLATE/frame_from_figma.md を追加し、画面実装依頼テンプレートを整備

# 懸念事項
- なし