### PR TITLE
ref data class 作成

### DIFF
--- a/lib/data/id/cycle_id.dart
+++ b/lib/data/id/cycle_id.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'cycle_id.freezed.dart';
+
+/// Cycle テーブルへの参照を表す値クラス。
+@freezed
+abstract class CycleId with _$CycleId {
+  /// [CycleId] を生成する。
+  const factory CycleId({required int id}) = _CycleId;
+}

--- a/lib/data/id/cycle_id.freezed.dart
+++ b/lib/data/id/cycle_id.freezed.dart
@@ -1,0 +1,271 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'cycle_id.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$CycleId {
+
+ int get id;
+/// Create a copy of CycleId
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CycleIdCopyWith<CycleId> get copyWith => _$CycleIdCopyWithImpl<CycleId>(this as CycleId, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CycleId&&(identical(other.id, id) || other.id == id));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'CycleId(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CycleIdCopyWith<$Res>  {
+  factory $CycleIdCopyWith(CycleId value, $Res Function(CycleId) _then) = _$CycleIdCopyWithImpl;
+@useResult
+$Res call({
+ int id
+});
+
+
+
+
+}
+/// @nodoc
+class _$CycleIdCopyWithImpl<$Res>
+    implements $CycleIdCopyWith<$Res> {
+  _$CycleIdCopyWithImpl(this._self, this._then);
+
+  final CycleId _self;
+  final $Res Function(CycleId) _then;
+
+/// Create a copy of CycleId
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [CycleId].
+extension CycleIdPatterns on CycleId {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CycleId value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CycleId() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CycleId value)  $default,){
+final _that = this;
+switch (_that) {
+case _CycleId():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CycleId value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CycleId() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CycleId() when $default != null:
+return $default(_that.id);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id)  $default,) {final _that = this;
+switch (_that) {
+case _CycleId():
+return $default(_that.id);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id)?  $default,) {final _that = this;
+switch (_that) {
+case _CycleId() when $default != null:
+return $default(_that.id);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _CycleId implements CycleId {
+  const _CycleId({required this.id});
+  
+
+@override final  int id;
+
+/// Create a copy of CycleId
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CycleIdCopyWith<_CycleId> get copyWith => __$CycleIdCopyWithImpl<_CycleId>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CycleId&&(identical(other.id, id) || other.id == id));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'CycleId(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CycleIdCopyWith<$Res> implements $CycleIdCopyWith<$Res> {
+  factory _$CycleIdCopyWith(_CycleId value, $Res Function(_CycleId) _then) = __$CycleIdCopyWithImpl;
+@override @useResult
+$Res call({
+ int id
+});
+
+
+
+
+}
+/// @nodoc
+class __$CycleIdCopyWithImpl<$Res>
+    implements _$CycleIdCopyWith<$Res> {
+  __$CycleIdCopyWithImpl(this._self, this._then);
+
+  final _CycleId _self;
+  final $Res Function(_CycleId) _then;
+
+/// Create a copy of CycleId
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,}) {
+  return _then(_CycleId(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/data/id/issue_id.dart
+++ b/lib/data/id/issue_id.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'issue_id.freezed.dart';
+
+/// Issue テーブルへの参照を表す値クラス。
+@freezed
+abstract class IssueId with _$IssueId {
+  /// [IssueId] を生成する。
+  const factory IssueId({required int id}) = _IssueId;
+}

--- a/lib/data/id/issue_id.freezed.dart
+++ b/lib/data/id/issue_id.freezed.dart
@@ -1,0 +1,271 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'issue_id.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$IssueId {
+
+ int get id;
+/// Create a copy of IssueId
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$IssueIdCopyWith<IssueId> get copyWith => _$IssueIdCopyWithImpl<IssueId>(this as IssueId, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is IssueId&&(identical(other.id, id) || other.id == id));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'IssueId(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $IssueIdCopyWith<$Res>  {
+  factory $IssueIdCopyWith(IssueId value, $Res Function(IssueId) _then) = _$IssueIdCopyWithImpl;
+@useResult
+$Res call({
+ int id
+});
+
+
+
+
+}
+/// @nodoc
+class _$IssueIdCopyWithImpl<$Res>
+    implements $IssueIdCopyWith<$Res> {
+  _$IssueIdCopyWithImpl(this._self, this._then);
+
+  final IssueId _self;
+  final $Res Function(IssueId) _then;
+
+/// Create a copy of IssueId
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [IssueId].
+extension IssueIdPatterns on IssueId {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _IssueId value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _IssueId() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _IssueId value)  $default,){
+final _that = this;
+switch (_that) {
+case _IssueId():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _IssueId value)?  $default,){
+final _that = this;
+switch (_that) {
+case _IssueId() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _IssueId() when $default != null:
+return $default(_that.id);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id)  $default,) {final _that = this;
+switch (_that) {
+case _IssueId():
+return $default(_that.id);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id)?  $default,) {final _that = this;
+switch (_that) {
+case _IssueId() when $default != null:
+return $default(_that.id);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _IssueId implements IssueId {
+  const _IssueId({required this.id});
+  
+
+@override final  int id;
+
+/// Create a copy of IssueId
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$IssueIdCopyWith<_IssueId> get copyWith => __$IssueIdCopyWithImpl<_IssueId>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _IssueId&&(identical(other.id, id) || other.id == id));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'IssueId(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$IssueIdCopyWith<$Res> implements $IssueIdCopyWith<$Res> {
+  factory _$IssueIdCopyWith(_IssueId value, $Res Function(_IssueId) _then) = __$IssueIdCopyWithImpl;
+@override @useResult
+$Res call({
+ int id
+});
+
+
+
+
+}
+/// @nodoc
+class __$IssueIdCopyWithImpl<$Res>
+    implements _$IssueIdCopyWith<$Res> {
+  __$IssueIdCopyWithImpl(this._self, this._then);
+
+  final _IssueId _self;
+  final $Res Function(_IssueId) _then;
+
+/// Create a copy of IssueId
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,}) {
+  return _then(_IssueId(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/data/id/status_id.dart
+++ b/lib/data/id/status_id.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'status_id.freezed.dart';
+
+/// Status テーブルへの参照を表す値クラス。
+@freezed
+abstract class StatusId with _$StatusId {
+  /// [StatusId] を生成する。
+  const factory StatusId({required int id}) = _StatusId;
+}

--- a/lib/data/id/status_id.freezed.dart
+++ b/lib/data/id/status_id.freezed.dart
@@ -1,0 +1,271 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'status_id.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$StatusId {
+
+ int get id;
+/// Create a copy of StatusId
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$StatusIdCopyWith<StatusId> get copyWith => _$StatusIdCopyWithImpl<StatusId>(this as StatusId, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StatusId&&(identical(other.id, id) || other.id == id));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'StatusId(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $StatusIdCopyWith<$Res>  {
+  factory $StatusIdCopyWith(StatusId value, $Res Function(StatusId) _then) = _$StatusIdCopyWithImpl;
+@useResult
+$Res call({
+ int id
+});
+
+
+
+
+}
+/// @nodoc
+class _$StatusIdCopyWithImpl<$Res>
+    implements $StatusIdCopyWith<$Res> {
+  _$StatusIdCopyWithImpl(this._self, this._then);
+
+  final StatusId _self;
+  final $Res Function(StatusId) _then;
+
+/// Create a copy of StatusId
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [StatusId].
+extension StatusIdPatterns on StatusId {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _StatusId value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _StatusId() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _StatusId value)  $default,){
+final _that = this;
+switch (_that) {
+case _StatusId():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _StatusId value)?  $default,){
+final _that = this;
+switch (_that) {
+case _StatusId() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _StatusId() when $default != null:
+return $default(_that.id);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id)  $default,) {final _that = this;
+switch (_that) {
+case _StatusId():
+return $default(_that.id);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id)?  $default,) {final _that = this;
+switch (_that) {
+case _StatusId() when $default != null:
+return $default(_that.id);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _StatusId implements StatusId {
+  const _StatusId({required this.id});
+  
+
+@override final  int id;
+
+/// Create a copy of StatusId
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$StatusIdCopyWith<_StatusId> get copyWith => __$StatusIdCopyWithImpl<_StatusId>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StatusId&&(identical(other.id, id) || other.id == id));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'StatusId(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$StatusIdCopyWith<$Res> implements $StatusIdCopyWith<$Res> {
+  factory _$StatusIdCopyWith(_StatusId value, $Res Function(_StatusId) _then) = __$StatusIdCopyWithImpl;
+@override @useResult
+$Res call({
+ int id
+});
+
+
+
+
+}
+/// @nodoc
+class __$StatusIdCopyWithImpl<$Res>
+    implements _$StatusIdCopyWith<$Res> {
+  __$StatusIdCopyWithImpl(this._self, this._then);
+
+  final _StatusId _self;
+  final $Res Function(_StatusId) _then;
+
+/// Create a copy of StatusId
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,}) {
+  return _then(_StatusId(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/data/local/database/no_zan_lane_database.g.dart
+++ b/lib/data/local/database/no_zan_lane_database.g.dart
@@ -829,7 +829,7 @@ class IssueData extends DataClass implements Insertable<IssueData> {
   /// ステータスID（statuses テーブルへの参照）。
   final int statusId;
 
-  /// 並び順（同じ cycleId, statusId 内での表示順。1 始まり。ユニークではない）。
+  /// 並び順（同じ cycleId, statusId 内での表示順。1 始まり。）。
   final int sortOrder;
   const IssueData({
     required this.id,

--- a/lib/data/local/service/issue_local_data_source.dart
+++ b/lib/data/local/service/issue_local_data_source.dart
@@ -25,12 +25,12 @@ class IssueLocalDataSource {
 
   /// 指定したサイクル・ステータスに属する Issue を sortOrder 昇順で返す。
   Future<List<IssueData>> list({
-    required CycleId cycle,
-    required StatusId status,
+    required CycleId cycleId,
+    required StatusId statusId,
   }) async {
     final query = _database.select(_database.issue)
       ..where(
-        (t) => t.cycleId.equals(cycle.id) & t.statusId.equals(status.id),
+        (t) => t.cycleId.equals(cycleId.id) & t.statusId.equals(statusId.id),
       )
       ..orderBy([
         (t) => OrderingTerm.asc(t.sortOrder),

--- a/lib/data/local/service/issue_local_data_source.dart
+++ b/lib/data/local/service/issue_local_data_source.dart
@@ -1,4 +1,6 @@
 import 'package:drift/drift.dart';
+import 'package:no_zan_lane/data/id/cycle_id.dart';
+import 'package:no_zan_lane/data/id/status_id.dart';
 import 'package:no_zan_lane/data/local/database/no_zan_lane_database.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -23,12 +25,12 @@ class IssueLocalDataSource {
 
   /// 指定したサイクル・ステータスに属する Issue を sortOrder 昇順で返す。
   Future<List<IssueData>> list({
-    required int cycleId,
-    required int statusId,
+    required CycleId cycle,
+    required StatusId status,
   }) async {
     final query = _database.select(_database.issue)
       ..where(
-        (t) => t.cycleId.equals(cycleId) & t.statusId.equals(statusId),
+        (t) => t.cycleId.equals(cycle.id) & t.statusId.equals(status.id),
       )
       ..orderBy([
         (t) => OrderingTerm.asc(t.sortOrder),

--- a/lib/data/local/service/issue_local_data_source.md
+++ b/lib/data/local/service/issue_local_data_source.md
@@ -42,9 +42,8 @@
 
 - `replaceAll(List<IssueCompanion> companions)`
   - Issue を全件置き換える。
-- `list(cycle: CycleId, status: StatusId)`
+- `list(cycleId: CycleId, statusId: StatusId)`
   - 指定したサイクル・ステータスに属する Issue を sortOrder 昇順で取得する。
-  - CycleId, StatusId は `lib/data/id/` で定義される。
 - `listAll()`
   - 全 Issue を cycleId, statusId, sortOrder, id の昇順で取得する。テスト・検証用。
 - `hasAny()`

--- a/lib/data/local/service/issue_local_data_source.md
+++ b/lib/data/local/service/issue_local_data_source.md
@@ -42,8 +42,9 @@
 
 - `replaceAll(List<IssueCompanion> companions)`
   - Issue を全件置き換える。
-- `list(cycleId, statusId)`
+- `list(cycle: CycleId, status: StatusId)`
   - 指定したサイクル・ステータスに属する Issue を sortOrder 昇順で取得する。
+  - CycleId, StatusId は `lib/data/id/` で定義される。
 - `listAll()`
   - 全 Issue を cycleId, statusId, sortOrder, id の昇順で取得する。テスト・検証用。
 - `hasAny()`

--- a/test/data/local/issue_local_data_source_test.dart
+++ b/test/data/local/issue_local_data_source_test.dart
@@ -2,6 +2,8 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:no_zan_lane/data/id/cycle_id.dart';
+import 'package:no_zan_lane/data/id/status_id.dart';
 import 'package:no_zan_lane/data/local/database/no_zan_lane_database.dart';
 import 'package:no_zan_lane/data/local/service/issue_local_data_source.dart';
 
@@ -51,7 +53,10 @@ void main() {
           sortOrder: 1,
         ),
       ]);
-      final issues = await dataSource.list(cycleId: 1, statusId: 1);
+      final issues = await dataSource.list(
+        cycle: const CycleId(id: 1),
+        status: const StatusId(id: 1),
+      );
 
       expect(issues.map((e) => e.id), [1, 2]);
       expect(issues.map((e) => e.title), ['First', 'Second']);

--- a/test/data/local/issue_local_data_source_test.dart
+++ b/test/data/local/issue_local_data_source_test.dart
@@ -54,8 +54,8 @@ void main() {
         ),
       ]);
       final issues = await dataSource.list(
-        cycle: const CycleId(id: 1),
-        status: const StatusId(id: 1),
+        cycleId: const CycleId(id: 1),
+        statusId: const StatusId(id: 1),
       );
 
       expect(issues.map((e) => e.id), [1, 2]);


### PR DESCRIPTION
close #68

# 概要

データレイヤーとプレゼンテーションレイヤーで共通して使う「Entity を指し示す」値クラス（CycleId, StatusId, IssueId）を追加し、IssueLocalDataSource の list メソッドの引数をその型に変更する。

# 変更内容

- `lib/data/id/` に freezed で id のみを持つ 3 クラスを追加
  - CycleId（Cycle テーブル参照）
  - StatusId（Status テーブル参照）
  - IssueId（Issue テーブル参照）
- IssueLocalDataSource.list の引数を `cycleId`, `statusId`（int）から `cycleId: CycleId`, `statusId: StatusId` に変更
- 仕様書（issue_local_data_source.md）を更新
- no_zan_lane_database.g.dart の Drift 生成コメント修正（本件とは無関係だが同梱）

# 懸念事項

特になし。