### PR TITLE
path_provider パッケージは使わない

### DIFF
--- a/lib/data/local/database/no_zan_lane_database.dart
+++ b/lib/data/local/database/no_zan_lane_database.dart
@@ -1,11 +1,9 @@
-import 'dart:io';
-
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
+import 'package:no_zan_lane/data/local/database/no_zan_lane_database_path.dart';
 import 'package:no_zan_lane/data/local/entity/cycle.dart';
 import 'package:no_zan_lane/data/local/entity/issue.dart';
 import 'package:no_zan_lane/data/local/entity/status.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'no_zan_lane_database.g.dart';
@@ -30,11 +28,7 @@ class NoZanLaneDatabase extends _$NoZanLaneDatabase {
 /// NoZanLaneDatabase の生成と初期化を担当する Provider。
 @riverpod
 Future<NoZanLaneDatabase> noZanLaneDatabase(Ref ref) async {
-  final applicationSupportDirectory = await getApplicationSupportDirectory();
-  await applicationSupportDirectory.create(recursive: true);
-  final databaseFile = File(
-    '${applicationSupportDirectory.path}/no_zan_lane.sqlite',
-  );
+  final databaseFile = await ensureNoZanLaneDatabaseFile();
 
   final database = NoZanLaneDatabase(
     executor: LazyDatabase(

--- a/lib/data/local/database/no_zan_lane_database.g.dart
+++ b/lib/data/local/database/no_zan_lane_database.g.dart
@@ -2110,4 +2110,4 @@ final class NoZanLaneDatabaseProvider
   }
 }
 
-String _$noZanLaneDatabaseHash() => r'd95792f613a69687724cca8733fbaaeb1257957b';
+String _$noZanLaneDatabaseHash() => r'4c7a0c35fe7e0e899a6d6bab22ea6d210e21c8f7';

--- a/lib/data/local/database/no_zan_lane_database_path.dart
+++ b/lib/data/local/database/no_zan_lane_database_path.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// データを置く既定ディレクトリ名（ユーザーのホーム直下）。
+const String kNoZanLaneDataDirName = '.NoZanLane';
+
+/// 既定の SQLite ファイル名。
+const String kNoZanLaneDatabaseFileName = 'database.sqlite';
+
+/// データディレクトリを上書きする環境変数名（直下に [kNoZanLaneDatabaseFileName]）。
+const String kNoZanLaneDataDirEnv = 'NO_ZANLANE_DATA_DIR';
+
+/// DB ファイルパスを完全指定する環境変数名。
+const String kNoZanLaneDbPathEnv = 'NO_ZANLANE_DB_PATH';
+
+/// デスクトップ／CLI 向けに、`~/.NoZanLane/database.sqlite` 相当のファイルを返す。
+///
+/// [environment] を省略すると [Platform.environment] を使う。テストでは Map を渡して差し替える。
+/// [kNoZanLaneDbPathEnv] が最優先、[kNoZanLaneDataDirEnv] が次、どちらも無ければホーム直下の既定パス。
+Future<File> ensureNoZanLaneDatabaseFile({
+  Map<String, String>? environment,
+}) async {
+  final env = environment ?? Platform.environment;
+
+  final dbPathOverride = _nonEmpty(env[kNoZanLaneDbPathEnv]);
+  if (dbPathOverride != null) {
+    final file = File(dbPathOverride);
+    await file.parent.create(recursive: true);
+    return file;
+  }
+
+  final dataDirOverride = _nonEmpty(env[kNoZanLaneDataDirEnv]);
+  if (dataDirOverride != null) {
+    final dir = Directory(dataDirOverride);
+    await dir.create(recursive: true);
+    return File(p.join(dir.path, kNoZanLaneDatabaseFileName));
+  }
+
+  final home = resolveUserHomeDirectory(env);
+  if (home == null) {
+    throw StateError(
+      'ユーザーのホームディレクトリを決定できません。'
+      'HOME（Unix）または USERPROFILE / HOME（Windows）を設定してください。',
+    );
+  }
+
+  final dataDir = Directory(p.join(home, kNoZanLaneDataDirName));
+  await dataDir.create(recursive: true);
+  return File(p.join(dataDir.path, kNoZanLaneDatabaseFileName));
+}
+
+/// ユーザーのホームディレクトリのパス。Windows は USERPROFILE を優先し、無ければ HOME。
+String? resolveUserHomeDirectory(Map<String, String> environment) {
+  if (Platform.isWindows) {
+    return _nonEmpty(environment['USERPROFILE']) ??
+        _nonEmpty(environment['HOME']);
+  }
+  return _nonEmpty(environment['HOME']);
+}
+
+String? _nonEmpty(String? value) {
+  if (value == null) {
+    return null;
+  }
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}

--- a/lib/data/local/database/no_zan_lane_database_path.dart
+++ b/lib/data/local/database/no_zan_lane_database_path.dart
@@ -8,34 +8,13 @@ const String kNoZanLaneDataDirName = '.NoZanLane';
 /// 既定の SQLite ファイル名。
 const String kNoZanLaneDatabaseFileName = 'database.sqlite';
 
-/// データディレクトリを上書きする環境変数名（直下に [kNoZanLaneDatabaseFileName]）。
-const String kNoZanLaneDataDirEnv = 'NO_ZANLANE_DATA_DIR';
-
-/// DB ファイルパスを完全指定する環境変数名。
-const String kNoZanLaneDbPathEnv = 'NO_ZANLANE_DB_PATH';
-
 /// デスクトップ／CLI 向けに、`~/.NoZanLane/database.sqlite` 相当のファイルを返す。
 ///
-/// [environment] を省略すると [Platform.environment] を使う。テストでは Map を渡して差し替える。
-/// [kNoZanLaneDbPathEnv] が最優先、[kNoZanLaneDataDirEnv] が次、どちらも無ければホーム直下の既定パス。
+/// [environment] は省略時 [Platform.environment]。テストでホームだけ差し替える場合に渡す。
 Future<File> ensureNoZanLaneDatabaseFile({
   Map<String, String>? environment,
 }) async {
   final env = environment ?? Platform.environment;
-
-  final dbPathOverride = _nonEmpty(env[kNoZanLaneDbPathEnv]);
-  if (dbPathOverride != null) {
-    final file = File(dbPathOverride);
-    await file.parent.create(recursive: true);
-    return file;
-  }
-
-  final dataDirOverride = _nonEmpty(env[kNoZanLaneDataDirEnv]);
-  if (dataDirOverride != null) {
-    final dir = Directory(dataDirOverride);
-    await dir.create(recursive: true);
-    return File(p.join(dir.path, kNoZanLaneDatabaseFileName));
-  }
 
   final home = resolveUserHomeDirectory(env);
   if (home == null) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,14 +153,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
-  code_assets:
-    dependency: transitive
-    description:
-      name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   code_builder:
     dependency: transitive
     description:
@@ -357,14 +349,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  hooks:
-    dependency: transitive
-    description:
-      name: hooks
-      sha256: "7a08a0d684cb3b8fb604b78455d5d352f502b68079f7b80b831c62220ab0a4f6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   hooks_riverpod:
     dependency: "direct main"
     description:
@@ -493,14 +477,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.3"
-  native_toolchain_c:
-    dependency: transitive
-    description:
-      name: native_toolchain_c
-      sha256: "89e83885ba09da5fdf2cdacc8002a712ca238c28b7f717910b34bcd27b0d03ac"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.17.4"
   nested:
     dependency: transitive
     description:
@@ -517,14 +493,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  objective_c:
-    dependency: transitive
-    description:
-      name: objective_c
-      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.0"
   package_config:
     dependency: transitive
     description:
@@ -534,69 +502,13 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  path_provider:
-    dependency: "direct main"
-    description:
-      name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.5"
-  path_provider_android:
-    dependency: transitive
-    description:
-      name: path_provider_android
-      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.22"
-  path_provider_foundation:
-    dependency: transitive
-    description:
-      name: path_provider_foundation
-      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.0"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.1"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  path_provider_windows:
-    dependency: transitive
-    description:
-      name: path_provider_windows
-      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.0"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -994,14 +906,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.22.0"
-  xdg_directories:
-    dependency: transitive
-    description:
-      name: xdg_directories
-      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   yaml:
     dependency: "direct main"
     description:
@@ -1012,4 +916,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   go_router: ^17.1.0
   hooks_riverpod: ^3.2.1
   intl: ^0.20.2
-  path_provider: ^2.1.5
+  path: ^1.9.1
   riverpod_annotation: ^4.0.2
   widgetbook: ^3.22.0
   widgetbook_annotation: ^3.11.0

--- a/test/data/local/database/no_zan_lane_database_path_test.dart
+++ b/test/data/local/database/no_zan_lane_database_path_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:no_zan_lane/data/local/database/no_zan_lane_database_path.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('ensureNoZanLaneDatabaseFile', () {
+    test('NO_ZANLANE_DB_PATH が最優先でディレクトリを作成する', () async {
+      final tmp = await Directory.systemTemp.createTemp('nozanlane_db_path_');
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final dbFile = File(p.join(tmp.path, 'nested', 'custom.sqlite'));
+      final resolved = await ensureNoZanLaneDatabaseFile(
+        environment: {
+          kNoZanLaneDbPathEnv: dbFile.path,
+          kNoZanLaneDataDirEnv: p.join(tmp.path, 'ignored'),
+          if (Platform.environment['HOME'] case final String home) 'HOME': home,
+          if (Platform.environment['USERPROFILE'] case final String userProfile)
+            'USERPROFILE': userProfile,
+        },
+      );
+
+      expect(resolved.path, dbFile.path);
+      expect(dbFile.parent.existsSync(), isTrue);
+    });
+
+    test('NO_ZANLANE_DATA_DIR の直下に database.sqlite を置く', () async {
+      final tmp = await Directory.systemTemp.createTemp('nozanlane_data_dir_');
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final resolved = await ensureNoZanLaneDatabaseFile(
+        environment: {
+          kNoZanLaneDataDirEnv: tmp.path,
+          if (Platform.environment['HOME'] case final String home) 'HOME': home,
+          if (Platform.environment['USERPROFILE'] case final String userProfile)
+            'USERPROFILE': userProfile,
+        },
+      );
+
+      expect(
+        resolved.path,
+        p.join(tmp.path, kNoZanLaneDatabaseFileName),
+      );
+      expect(tmp.existsSync(), isTrue);
+    });
+
+    test('環境変数が無いとき HOME 直下の .NoZanLane/database.sqlite', () async {
+      final tmp = await Directory.systemTemp.createTemp('nozanlane_home_');
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final resolved = await ensureNoZanLaneDatabaseFile(
+        environment: {
+          'HOME': tmp.path,
+          if (Platform.isWindows) 'USERPROFILE': tmp.path,
+        },
+      );
+
+      expect(
+        resolved.path,
+        p.join(tmp.path, kNoZanLaneDataDirName, kNoZanLaneDatabaseFileName),
+      );
+      expect(
+        Directory(p.join(tmp.path, kNoZanLaneDataDirName)).existsSync(),
+        isTrue,
+      );
+    });
+
+    test('HOME が無くてパスを決められないときは StateError', () async {
+      await expectLater(
+        ensureNoZanLaneDatabaseFile(environment: {}),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('resolveUserHomeDirectory', () {
+    test('Windows では USERPROFILE を優先する', () {
+      expect(
+        resolveUserHomeDirectory({
+          'USERPROFILE': r'C:\Users\Test',
+          'HOME': '/fallback',
+        }),
+        r'C:\Users\Test',
+      );
+    }, skip: !Platform.isWindows);
+
+    test('Windows で USERPROFILE が無いとき HOME', () {
+      expect(
+        resolveUserHomeDirectory({'HOME': r'D:\home'}),
+        r'D:\home',
+      );
+    }, skip: !Platform.isWindows);
+
+    test('Unix では HOME を使う', () {
+      expect(
+        resolveUserHomeDirectory({'HOME': '/Users/x'}),
+        '/Users/x',
+      );
+    }, skip: Platform.isWindows);
+  });
+}

--- a/test/data/local/database/no_zan_lane_database_path_test.dart
+++ b/test/data/local/database/no_zan_lane_database_path_test.dart
@@ -6,46 +6,7 @@ import 'package:path/path.dart' as p;
 
 void main() {
   group('ensureNoZanLaneDatabaseFile', () {
-    test('NO_ZANLANE_DB_PATH が最優先でディレクトリを作成する', () async {
-      final tmp = await Directory.systemTemp.createTemp('nozanlane_db_path_');
-      addTearDown(() async => tmp.delete(recursive: true));
-
-      final dbFile = File(p.join(tmp.path, 'nested', 'custom.sqlite'));
-      final resolved = await ensureNoZanLaneDatabaseFile(
-        environment: {
-          kNoZanLaneDbPathEnv: dbFile.path,
-          kNoZanLaneDataDirEnv: p.join(tmp.path, 'ignored'),
-          if (Platform.environment['HOME'] case final String home) 'HOME': home,
-          if (Platform.environment['USERPROFILE'] case final String userProfile)
-            'USERPROFILE': userProfile,
-        },
-      );
-
-      expect(resolved.path, dbFile.path);
-      expect(dbFile.parent.existsSync(), isTrue);
-    });
-
-    test('NO_ZANLANE_DATA_DIR の直下に database.sqlite を置く', () async {
-      final tmp = await Directory.systemTemp.createTemp('nozanlane_data_dir_');
-      addTearDown(() async => tmp.delete(recursive: true));
-
-      final resolved = await ensureNoZanLaneDatabaseFile(
-        environment: {
-          kNoZanLaneDataDirEnv: tmp.path,
-          if (Platform.environment['HOME'] case final String home) 'HOME': home,
-          if (Platform.environment['USERPROFILE'] case final String userProfile)
-            'USERPROFILE': userProfile,
-        },
-      );
-
-      expect(
-        resolved.path,
-        p.join(tmp.path, kNoZanLaneDatabaseFileName),
-      );
-      expect(tmp.existsSync(), isTrue);
-    });
-
-    test('環境変数が無いとき HOME 直下の .NoZanLane/database.sqlite', () async {
+    test('HOME 直下の .NoZanLane/database.sqlite を作成する', () async {
       final tmp = await Directory.systemTemp.createTemp('nozanlane_home_');
       addTearDown(() async => tmp.delete(recursive: true));
 


### PR DESCRIPTION
close #72

# 概要

`path_provider` に依存せず、`dart:io` と `path` のみで SQLite の場所を解決するようにしました。本番ではユーザー主ディレクトリ直下の `.NoZanLane/database.sqlite` のみを使用します（Flutter と将来の CLI で同一ファイルを参照可能）。

# 変更内容

- `lib/data/local/database/no_zan_lane_database_path.dart` を追加し、`ensureNoZanLaneDatabaseFile` と `resolveUserHomeDirectory` でホーム取得〜ディレクトリ作成〜ファイルパス返却までを一元化しました。
- `noZanLaneDatabase` は `getApplicationSupportDirectory()` をやめ、上記で取得したファイルで `NativeDatabase` を開きます。
- `pubspec.yaml` から `path_provider` を削除し、`path` を直接依存として追加しました。
- パス解決の単体テストを `test/data/local/database/no_zan_lane_database_path_test.dart` に追加しました。
- （追記）`NO_ZANLANE_DB_PATH` / `NO_ZANLANE_DATA_DIR` などの独自環境変数による上書きは入れていません。

# 懸念事項

- 以前 Application Support にあった `no_zan_lane.sqlite` からの自動コピーは行っていません（Issue のマイグレーションは別タスク判断）。
- create-pr スキルにより README は変更していません。既定パスの説明は `no_zan_lane_database_path.dart` のドキュメントコメントに記載しています。